### PR TITLE
BugFix: ApplicationInfo throws a Null Exception when loaded by xUnit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Elements is a set of reusable components commonly used in applications.
 
 | Package | description  | nuget Stable |
 | ------- | ------------ | -------------|
-| [Structum.Elements](https://www.nuget.org/packages/Structum.Elements/) | Common classes and Type extensions | [![nuget](https://img.shields.io/badge/nuget-v1.2.3.1-blue.svg)](https://www.nuget.org/packages/Structum.Elements) |
-| [Structum.Elements.Web](https://www.nuget.org/packages/Structum.Elements.Web/) | Lightweight Rest Requests and URL parser. | [![nuget](https://img.shields.io/badge/nuget-v1.2.3.1-blue.svg)](https://www.nuget.org/packages/Structum.Elements.Web) |
-| [Structum.Elements.Security](https://www.nuget.org/packages/Structum.Elements.Security/) | Common Encryption, Hashing and Password protection classes. | [![nuget](https://img.shields.io/badge/nuget-v1.2.3.1-blue.svg)](https://www.nuget.org/packages/Structum.Elements.Security) |
-| [Structum.Elements.Data](https://www.nuget.org/packages/Structum.Elements.Data/) | Data Structures and Hash Functions. | [![nuget](https://img.shields.io/badge/nuget-v1.2.3.1-blue.svg)](https://www.nuget.org/packages/Structum.Elements.Data) |
+| [Structum.Elements](https://www.nuget.org/packages/Structum.Elements/) | Common classes and Type extensions | [![nuget](https://img.shields.io/badge/nuget-v1.2.4.1-blue.svg)](https://www.nuget.org/packages/Structum.Elements) |
+| [Structum.Elements.Web](https://www.nuget.org/packages/Structum.Elements.Web/) | Lightweight Rest Requests and URL parser. | [![nuget](https://img.shields.io/badge/nuget-v1.2.4.1-blue.svg)](https://www.nuget.org/packages/Structum.Elements.Web) |
+| [Structum.Elements.Security](https://www.nuget.org/packages/Structum.Elements.Security/) | Common Encryption, Hashing and Password protection classes. | [![nuget](https://img.shields.io/badge/nuget-v1.2.4.1-blue.svg)](https://www.nuget.org/packages/Structum.Elements.Security) |
+| [Structum.Elements.Data](https://www.nuget.org/packages/Structum.Elements.Data/) | Data Structures and Hash Functions. | [![nuget](https://img.shields.io/badge/nuget-v1.2.4.1-blue.svg)](https://www.nuget.org/packages/Structum.Elements.Data) |
 
 ## Getting Started
 

--- a/src/Elements/Environment/ApplicationInfo.cs
+++ b/src/Elements/Environment/ApplicationInfo.cs
@@ -28,36 +28,36 @@ namespace Structum.Elements.Environment
         ///     Gets or Sets the application name.
         /// </summary>
         /// <value>A string containing the name of the application file. (e.g. Photoshop.exe)(</value>
-        public string Name { get; set; }
+        public string Name { get; set; } = string.Empty;
 
         /// <summary>
         ///     Gets or Sets the application version.
         /// </summary>
         /// <value>A string containing the application version. (e.g. 1.0.0.0)</value>
-        public string Version { get; set; }
+        public string Version { get; set; } = string.Empty;
 
         /// <summary>
         ///     Gets or Sets the application company name.
         /// </summary>
         /// <value>A string containing the Company Name that owns the application. (e.g. Adobe, Inc.)</value>
-        public string CompanyName { get; set; }
+        public string CompanyName { get; set; } = string.Empty;
 
         /// <summary>
         ///     Gets or Sets the application file path.
         /// </summary>
         /// <value>A string containing the full application path. (e.g. C:\Program Files\Adobe Photoshop\Photoshop.exe)</value>
-        public string FilePath { get; set; }
+        public string FilePath { get; set; } = string.Empty;
 
         /// <summary>
         ///     Gets or Sets the application executing directory.
         /// </summary>
         /// <value>A string containing the Executing directory for the application. (e.g. C:\\Program Files\\Adobe Photoshop\\")</value>
-        public string ExecutingDirectory { get; set; }
+        public string ExecutingDirectory { get; set; } = string.Empty;
 
         /// <summary>
         ///     Gets or Sets the application command line arguments.
         /// </summary>
         /// <value>A string containing command-line arguments. (e.g. -c)</value>
-        public string[] CommandArguments { get; set; }
+        public string[] CommandArguments { get; set; } = { };
     }
 }

--- a/src/Elements/Environment/ApplicationInfoFactory.cs
+++ b/src/Elements/Environment/ApplicationInfoFactory.cs
@@ -18,36 +18,30 @@ namespace Structum.Elements.Environment
         /// <summary>
         ///     Creates and returns the Current Application information.
         /// </summary>
+        /// <remarks>
+        ///     This method can gather the information for the Current Executing Application if it is a managed .Net application; when this is not the case this method will
+        ///     return an application information class with empty values.
+        /// </remarks>
         /// <returns>Current Application Information.</returns>
         public static ApplicationInfo CreateCurrentApplicationInfo()
         {
             Assembly asm = Assembly.GetEntryAssembly();
-            ApplicationInfo currApp = new ApplicationInfo {
-                Name = Path.GetFileName(System.Environment.GetCommandLineArgs()[0]),
-                Version = asm.GetName().Version.ToString(),
-                ExecutingDirectory = GetExecutingDirectory(asm),
-                CommandArguments = System.Environment.GetCommandLineArgs(),
-                CompanyName = FileVersionInfo.GetVersionInfo(asm.Location).CompanyName
-            };
-            currApp.FilePath = Path.Combine(currApp.ExecutingDirectory, currApp.Name ?? "");
 
-            return currApp;
-        }
-
-        /// <summary>
-        /// 	Returns the application directory.
-        /// </summary>
-        /// <param name="asm">Assembly to the Executing Directory from.</param>
-        /// <returns>Application Directory.</returns>
-        private static string GetExecutingDirectory(Assembly asm)
-        {
-            string replaceText = "file://";
-            if(ExecutingEnvironment.LocalPlatform.OsPlatform == OsPlatformType.Windows) {
-                replaceText = "file:///";
+            if (asm == null) {
+                return new ApplicationInfo {
+                    ExecutingDirectory = System.AppDomain.CurrentDomain.BaseDirectory
+                };
             }
 
-            string codeBase = asm.GetName().CodeBase.Replace(replaceText, "");
-            return Path.GetDirectoryName(codeBase);
+            string name = Path.GetFileName(System.Environment.GetCommandLineArgs()[0]);
+            return new ApplicationInfo {
+                Name = name,
+                Version = asm.GetName().Version.ToString(),
+                ExecutingDirectory =  System.AppDomain.CurrentDomain.BaseDirectory,
+                CommandArguments = System.Environment.GetCommandLineArgs(),
+                CompanyName = FileVersionInfo.GetVersionInfo(asm.Location).CompanyName,
+                FilePath = Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory, name ?? "")
+            };
         }
     }
 }


### PR DESCRIPTION
Fixed a bug related to ApplicationInfo when the library is being loaded by an application that might not be a managed .net app