### PR TITLE
Downgraded fastJSON to 2.3.3 because of an issue with ToObject

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,17 @@ Elements is a set of reusable components commonly used in applications.
 
 | Package | description  | nuget Stable |
 | ------- | ------------ | -------------|
-| [Structum.Elements](https://www.nuget.org/packages/Structum.Elements/) | Common classes and Type extensions | [![nuget](https://img.shields.io/badge/nuget-v1.2.4.4-blue.svg)](https://www.nuget.org/packages/Structum.Elements) |
-| [Structum.Elements.Web](https://www.nuget.org/packages/Structum.Elements.Web/) | Lightweight Rest Requests and URL parser. | [![nuget](https://img.shields.io/badge/nuget-v1.2.4.4-blue.svg)](https://www.nuget.org/packages/Structum.Elements.Web) |
-| [Structum.Elements.Security](https://www.nuget.org/packages/Structum.Elements.Security/) | Common Encryption, Hashing and Password protection classes. | [![nuget](https://img.shields.io/badge/nuget-v1.2.4.4-blue.svg)](https://www.nuget.org/packages/Structum.Elements.Security) |
-| [Structum.Elements.Data](https://www.nuget.org/packages/Structum.Elements.Data/) | Data Structures and Hash Functions. | [![nuget](https://img.shields.io/badge/nuget-v1.2.4.4-blue.svg)](https://www.nuget.org/packages/Structum.Elements.Data) |
+| [Structum.Elements](https://www.nuget.org/packages/Structum.Elements/) | Common classes and Type extensions | [![nuget](https://img.shields.io/badge/nuget-v1.2.4.5-blue.svg)](https://www.nuget.org/packages/Structum.Elements) |
+| [Structum.Elements.Web](https://www.nuget.org/packages/Structum.Elements.Web/) | Lightweight Rest Requests and URL parser. | [![nuget](https://img.shields.io/badge/nuget-v1.2.4.5-blue.svg)](https://www.nuget.org/packages/Structum.Elements.Web) |
+| [Structum.Elements.Security](https://www.nuget.org/packages/Structum.Elements.Security/) | Common Encryption, Hashing and Password protection classes. | [![nuget](https://img.shields.io/badge/nuget-v1.2.4.5-blue.svg)](https://www.nuget.org/packages/Structum.Elements.Security) |
+| [Structum.Elements.Data](https://www.nuget.org/packages/Structum.Elements.Data/) | Data Structures and Hash Functions. | [![nuget](https://img.shields.io/badge/nuget-v1.2.4.5-blue.svg)](https://www.nuget.org/packages/Structum.Elements.Data) |
 
 ## Getting Started
 
 ### Dependencies
 
 * .NETStandard 2.1
-* [fastJSON](https://www.nuget.org/packages/fastJSON/) (>= 2.4.0)
+* [fastJSON](https://www.nuget.org/packages/fastJSON/) (>= 2.3.3)
 
 
 ### Installing

--- a/src/Elements.Data/Elements.Data.csproj
+++ b/src/Elements.Data/Elements.Data.csproj
@@ -18,7 +18,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="fastJSON" Version="2.4.0.1" />
+      <PackageReference Include="fastJSON" Version="2.3.3" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Downgraded fastJSON to 2.3.3 because of  bug in fastJSON 2.4.0.1 regarding ToObject.